### PR TITLE
feat: convert to news

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.5.0-alpha.0](https://github.com/RedTurtle/volto-ufficiostampa/compare/1.4.0...1.5.0-alpha.0) (2026-05-22)
+
+### Features
+
+* convert to news implemented ([bc8b0de](https://github.com/RedTurtle/volto-ufficiostampa/commit/bc8b0dee47d44a67e75a677d12d28bb99a3f042c))
+
+### Bug Fixes
+
+* allineamento con BE e gestione errore ([8da433d](https://github.com/RedTurtle/volto-ufficiostampa/commit/8da433d80668a0f9d1ece355647245a714addac5))
+* settings enabled/disabled+ ([430485d](https://github.com/RedTurtle/volto-ufficiostampa/commit/430485d387abc6f1a0ba01ea904fda89024bb045))
+
+### Maintenance
+
+* locales ([f2d40f4](https://github.com/RedTurtle/volto-ufficiostampa/commit/f2d40f49297b617e3c6baffb65247bb4c765fdbd))
+
 ## [1.4.0](https://github.com/RedTurtle/volto-ufficiostampa/compare/1.3.1...1.4.0) (2026-01-26)
 
 ### Features

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -581,6 +581,31 @@ msgstr ""
 msgid "ufficiostampa_comunicato_type"
 msgstr ""
 
+#. Default: "Si è verificato un errore durante la creazione della notizia."
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_error_text"
+msgstr ""
+
+#. Default: "Errore"
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_error_title"
+msgstr ""
+
+#. Default: "Crea notizia"
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_label"
+msgstr ""
+
+#. Default: "La notizia è stata creata con successo."
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_success_text"
+msgstr ""
+
+#. Default: "Notizia creata"
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_success_title"
+msgstr ""
+
 #. Default: "Filter title"
 #: components/manage/SendHistoryPanel/messages
 msgid "ufficiostampa_history_panel_filter_title"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -581,6 +581,31 @@ msgstr "Titolo"
 msgid "ufficiostampa_comunicato_type"
 msgstr "Tipologia"
 
+#. Default: "Si è verificato un errore durante la creazione della notizia."
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_error_text"
+msgstr ""
+
+#. Default: "Errore"
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_error_title"
+msgstr ""
+
+#. Default: "Crea notizia"
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_label"
+msgstr ""
+
+#. Default: "La notizia è stata creata con successo."
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_success_text"
+msgstr ""
+
+#. Default: "Notizia creata"
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_success_title"
+msgstr ""
+
 #. Default: "Filter title"
 #: components/manage/SendHistoryPanel/messages
 msgid "ufficiostampa_history_panel_filter_title"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2026-01-22T13:13:13.771Z\n"
+"POT-Creation-Date: 2026-05-22T11:45:01.715Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -581,6 +581,31 @@ msgstr ""
 #. Default: "Type"
 #: components/manage/SendHistoryPanel/messages
 msgid "ufficiostampa_comunicato_type"
+msgstr ""
+
+#. Default: "Si è verificato un errore durante la creazione della notizia."
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_error_text"
+msgstr ""
+
+#. Default: "Errore"
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_error_title"
+msgstr ""
+
+#. Default: "Crea notizia"
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_label"
+msgstr ""
+
+#. Default: "La notizia è stata creata con successo."
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_success_text"
+msgstr ""
+
+#. Default: "Notizia creata"
+#: components/Menu/Menu
+msgid "ufficiostampa_convert_to_news_success_title"
 msgstr ""
 
 #. Default: "Filter title"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "volto-ufficiostampa",
-  "version": "1.4.0",
+  "version": "1.5.0-alpha.0",
   "description": "volto-ufficiostampa: Volto add-on",
   "main": "src/index.js",
   "license": "MIT",

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,3 +1,4 @@
+export const CONVERT_TO_NEWS = 'CONVERT_TO_NEWS';
 export const GET_SENDCOMUNICATO_SCHEMA = 'GET_SENDCOMUNICATO_SCHEMA';
 export const GET_SENDCOMUNICATO_SCHEMA_RESET =
   'GET_SENDCOMUNICATO_SCHEMA_RESET';
@@ -129,6 +130,20 @@ export function getSendHistory(data) {
       params: data,
     },
   };
+}
+
+export function convertToNews(url) {
+  return {
+    type: CONVERT_TO_NEWS,
+    request: {
+      op: 'post',
+      path: `${url}/@converti-news`,
+    },
+  };
+}
+
+export function resetConvertToNews() {
+  return { type: `${CONVERT_TO_NEWS}_RESET` };
 }
 
 export function deleteSendHistory(data) {

--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -1,11 +1,47 @@
+import { Toast } from '@plone/volto/components';
+import { Icon } from '@plone/volto/components';
 import { Plug } from '@plone/volto/components/manage/Pluggable';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import rightArrowSVG from '@plone/volto/icons/right-key.svg';
+import { useEffect } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { Icon } from '@plone/volto/components';
+import { toast } from 'react-toastify';
+import { convertToNews, resetConvertToNews } from '../../actions';
+
+const messages = defineMessages({
+  convert_to_news: {
+    id: 'ufficiostampa_convert_to_news_label',
+    defaultMessage: 'Crea notizia',
+  },
+  success_title: {
+    id: 'ufficiostampa_convert_to_news_success_title',
+    defaultMessage: 'Notizia creata',
+  },
+  success_text: {
+    id: 'ufficiostampa_convert_to_news_success_text',
+    defaultMessage: 'La notizia è stata creata con successo.',
+  },
+  error_title: {
+    id: 'ufficiostampa_convert_to_news_error_title',
+    defaultMessage: 'Errore',
+  },
+  error_text: {
+    id: 'ufficiostampa_convert_to_news_error_text',
+    defaultMessage:
+      'Si è verificato un errore durante la creazione della notizia.',
+  },
+});
+
+const COMUNICATO_TYPES = ['ComunicatoStampa', 'InvitoStampa'];
 
 const SendMenu = (props) => {
   const { content } = props;
+  const intl = useIntl();
+  const dispatch = useDispatch();
+  const convertStatus = useSelector((state) => state?.convertToNews);
+
   const actionIds = [
     'ufficiostampa-channels-management',
     'ufficiostampa-history-management',
@@ -16,6 +52,33 @@ const SendMenu = (props) => {
   const filteredActions = actionIds
     .map((id) => actions.find((action) => action.id === id))
     .filter(Boolean);
+
+  const isComunicato = COMUNICATO_TYPES.includes(content?.['@type']);
+
+  useEffect(() => {
+    if (!convertStatus?.loaded) return;
+    if (!convertStatus?.error) {
+      toast.success(
+        <Toast
+          success
+          title={intl.formatMessage(messages.success_title)}
+          content={intl.formatMessage(messages.success_text)}
+        />,
+      );
+      dispatch(resetConvertToNews());
+      // TODO: sostituire con l'url tornato dal BE: convertStatus?.result?.url
+      window.location.href = 'https://example.com';
+    } else {
+      toast.error(
+        <Toast
+          error
+          title={intl.formatMessage(messages.error_title)}
+          content={intl.formatMessage(messages.error_text)}
+        />,
+      );
+      dispatch(resetConvertToNews());
+    }
+  }, [convertStatus?.loaded, convertStatus?.error]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <>
@@ -41,6 +104,27 @@ const SendMenu = (props) => {
           </Plug>
         );
       })}
+      {isComunicato && (
+        <Plug
+          pluggable="toolbar-more-manage-content"
+          id="ufficiostampa-convert-to-news"
+        >
+          <li>
+            <button
+              className="ufficiostampa-toolbar-action"
+              onClick={() => dispatch(convertToNews(content['@id']))}
+            >
+              <div>
+                <span className="pastanaga-menu-label">
+                  {intl.formatMessage(messages.convert_to_news)}
+                </span>
+                <span className="pastanaga-menu-value" />
+              </div>
+              <Icon name={rightArrowSVG} size="24px" />
+            </button>
+          </li>
+        </Plug>
+      )}
     </>
   );
 };

--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -66,14 +66,16 @@ const SendMenu = (props) => {
         />,
       );
       dispatch(resetConvertToNews());
-      // TODO: sostituire con l'url tornato dal BE: convertStatus?.result?.url
-      window.location.href = 'https://example.com';
+      window.location.href = convertStatus?.result?.url;
     } else {
       toast.error(
         <Toast
           error
           title={intl.formatMessage(messages.error_title)}
-          content={intl.formatMessage(messages.error_text)}
+          content={
+            convertStatus?.error.response.body.message ||
+            intl.formatMessage(messages.error_text)
+          }
         />,
       );
       dispatch(resetConvertToNews());
@@ -112,7 +114,9 @@ const SendMenu = (props) => {
           <li>
             <button
               className="ufficiostampa-toolbar-action"
-              onClick={() => dispatch(convertToNews(content['@id']))}
+              onClick={() =>
+                dispatch(convertToNews(flattenToAppURL(content['@id'])))
+              }
             >
               <div>
                 <span className="pastanaga-menu-label">

--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -9,6 +9,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { convertToNews, resetConvertToNews } from '../../actions';
+import config from '@plone/volto/registry';
 
 const messages = defineMessages({
   convert_to_news: {
@@ -106,7 +107,7 @@ const SendMenu = (props) => {
           </Plug>
         );
       })}
-      {isComunicato && (
+      {isComunicato && config.settings.UfficioStampa?.convertToNews && (
         <Plug
           pluggable="toolbar-more-manage-content"
           id="ufficiostampa-convert-to-news"

--- a/src/components/manage/modals.css
+++ b/src/components/manage/modals.css
@@ -77,6 +77,19 @@
   margin-right: 10px;
 }
 
+.cms-ui li button.ufficiostampa-toolbar-action {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: inherit;
+  text-align: left;
+}
+
 .ufficiostampa-modal form {
   max-height: 70vh;
   overflow-y: scroll;

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import {
 } from './components';
 
 import {
+  convertToNewsReducer,
   sendComunicatoSchemaReducer,
   sendComunicatoReducer,
   getSubscriptionsReducer,
@@ -107,6 +108,7 @@ const applyConfig = (config) => {
   ];
   config.addonReducers = {
     ...config.addonReducers,
+    convertToNews: convertToNewsReducer,
     comunicatoSchemaReducer: sendComunicatoSchemaReducer,
     comunicatoSendReducer: sendComunicatoReducer,
     // manageChannels

--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,9 @@ const applyConfig = (config) => {
     '/@send-comunicato',
     '/dettaglio-comunicato-archive/',
   ];
+  config.settings.UfficioStampa = {
+    convertToNews: false,
+  };
   config.addonReducers = {
     ...config.addonReducers,
     convertToNews: convertToNewsReducer,

--- a/src/reducers/convertToNews.js
+++ b/src/reducers/convertToNews.js
@@ -1,0 +1,35 @@
+import { CONVERT_TO_NEWS } from '../actions';
+
+const initialState = {
+  error: null,
+  result: null,
+  loading: false,
+  loaded: false,
+};
+
+export const convertToNewsReducer = (state = initialState, action = {}) => {
+  switch (action.type) {
+    case `${CONVERT_TO_NEWS}_PENDING`:
+      return { ...state, loading: true, loaded: false, error: null };
+    case `${CONVERT_TO_NEWS}_SUCCESS`:
+      return {
+        ...state,
+        loading: false,
+        loaded: true,
+        result: action.result,
+        error: null,
+      };
+    case `${CONVERT_TO_NEWS}_FAIL`:
+      return {
+        ...state,
+        loading: false,
+        loaded: true,
+        result: null,
+        error: action.error,
+      };
+    case `${CONVERT_TO_NEWS}_RESET`:
+      return initialState;
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,3 +1,4 @@
+import { convertToNewsReducer } from './convertToNews';
 import {
   sendComunicatoSchemaReducer,
   sendComunicatoReducer,
@@ -25,6 +26,7 @@ import {
 } from './personal_channels_management';
 
 export {
+  convertToNewsReducer,
   sendComunicatoSchemaReducer,
   sendComunicatoReducer,
   getSubscriptionsReducer,


### PR DESCRIPTION
Azione contestuale al comunicato per creare una notizia a partire ad un comunicato stampa, richiede l'implementazione in backend di uuna restapi POST `@converti-news` nel contesto del comunicato che crea la notizia e torna nel json la ul della notiizia creata o un messaggio di errore.

La funzionalià è di default non abilitata, per abilitarla settarre la config `config.settings.UfficioStampa.convertToNews` a true